### PR TITLE
docs(autofill-credentials): Add warning about hostname and apis

### DIFF
--- a/docs/main/guides/autofill-credentials.md
+++ b/docs/main/guides/autofill-credentials.md
@@ -89,6 +89,10 @@ const config: CapacitorConfig = {
 };
 ```
 
+:::note
+  If you intend to make network requests to an API on the same domain, you must use a subdomain for the API, otherwise your network request will be routed locally to the native app. `api.my-app.com` will work, `my-app.com/api` will not
+:::
+
 ## Configuration for iOS
 
 ### Configuration in XCode


### PR DESCRIPTION
A big footgun for me when implementing server.hostname to match my live site was the app stopped working because it was making network requests to the same domain.com/api which Capacitor was routing internally to itself instead.